### PR TITLE
Fix Distance Display Output

### DIFF
--- a/Throne/Models/Building.swift
+++ b/Throne/Models/Building.swift
@@ -14,7 +14,7 @@ final class Building: Codable, ObservableObject, Hashable {
     var id: Int
     var title: String
     var location: Location
-    var distance: Double? // meters
+    var distance: Double? // kilometers
     var washroomsCount: Int?
     var createdAt: Date
     var overallRating: Double
@@ -116,11 +116,12 @@ final class Building: Codable, ObservableObject, Hashable {
     var distanceDescription: String {
         get {
             if let distance = self.distance {
-                if distance < 1000.0 {
-                    let value = String(format: "%.0f", distance)
+                NSLog(String(format: "%f", distance))
+                if distance < 1.0 {
+                    let value = String(format: "%.0f", distance * 1000.0)
                     return "\(value) m"
                 } else {
-                    let value = String(format: "%.1f", distance / 1000.0)
+                    let value = String(format: "%.1f", distance)
                     return "\(value) km"
                 }
             } else {

--- a/Throne/Models/LocationManager.swift
+++ b/Throne/Models/LocationManager.swift
@@ -33,7 +33,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     func setupLocationManager() {
         // start tracking location
         locationManager.delegate = self
-        locationManager.distanceFilter = 20.0 // meters
+        locationManager.distanceFilter = 0.020 // kilometers
         locationManager.startUpdatingLocation()
         if let location = locationManager.location {
             currentLocation = Location(location.coordinate)

--- a/Throne/Models/Washroom.swift
+++ b/Throne/Models/Washroom.swift
@@ -15,7 +15,7 @@ final class Washroom: Codable, ObservableObject, Hashable {
     var buildingTitle: String
     var additionalTitle: String
     var location: Location
-    var distance: Double? // meters
+    var distance: Double? // kilometers
     var gender: Gender
     var floor: Int
     var stallsCount: Int
@@ -186,11 +186,11 @@ final class Washroom: Codable, ObservableObject, Hashable {
     var distanceDescription: String {
         get {
             if let distance = self.distance {
-                if distance < 1000.0 {
-                    let value = String(format: "%.0f", distance)
+                if distance < 1.0 {
+                    let value = String(format: "%.0f", distance * 1000.0)
                     return "\(value) m"
                 } else {
-                    let value = String(format: "%.1f", distance / 1000.0)
+                    let value = String(format: "%.1f", distance)
                     return "\(value) km"
                 }
             } else {

--- a/ThroneTests/BuildingTest.swift
+++ b/ThroneTests/BuildingTest.swift
@@ -74,23 +74,23 @@ class BuildingTest: XCTestCase {
         
         building.distance = 0.1
         distanceDescription = building.distanceDescription
-        XCTAssertEqual(distanceDescription, "0 m")
+        XCTAssertEqual(distanceDescription, "100 m")
         
         building.distance = 100
         distanceDescription = building.distanceDescription
-        XCTAssertEqual(distanceDescription, "100 m")
+        XCTAssertEqual(distanceDescription, "100.0 km")
         
-        building.distance = 100.9999
+        building.distance = 0.1009999
         distanceDescription = building.distanceDescription
         XCTAssertEqual(distanceDescription, "101 m")
         
-        building.distance = 1100
+        building.distance = 1.100
         distanceDescription = building.distanceDescription
         XCTAssertEqual(distanceDescription, "1.1 km")
         
-        building.distance = 10000.999999
+        building.distance = 10.999999
         distanceDescription = building.distanceDescription
-        XCTAssertEqual(distanceDescription, "10.0 km")
+        XCTAssertEqual(distanceDescription, "11.0 km")
         
         building.distance = nil
         distanceDescription = building.distanceDescription

--- a/ThroneTests/WashroomTest.swift
+++ b/ThroneTests/WashroomTest.swift
@@ -45,23 +45,23 @@ class WashroomTest: XCTestCase {
         
         washroom.distance = 0.1
         distanceDescription = washroom.distanceDescription
-        XCTAssertEqual(distanceDescription, "0 m")
+        XCTAssertEqual(distanceDescription, "100 m")
         
         washroom.distance = 100
         distanceDescription = washroom.distanceDescription
-        XCTAssertEqual(distanceDescription, "100 m")
+        XCTAssertEqual(distanceDescription, "100.0 km")
         
-        washroom.distance = 100.9999
+        washroom.distance = 0.1009999
         distanceDescription = washroom.distanceDescription
         XCTAssertEqual(distanceDescription, "101 m")
         
-        washroom.distance = 1100
+        washroom.distance = 1.100
         distanceDescription = washroom.distanceDescription
         XCTAssertEqual(distanceDescription, "1.1 km")
         
-        washroom.distance = 10000.999999
+        washroom.distance = 10.999999
         distanceDescription = washroom.distanceDescription
-        XCTAssertEqual(distanceDescription, "10.0 km")
+        XCTAssertEqual(distanceDescription, "11.0 km")
         
         washroom.distance = nil
         distanceDescription = washroom.distanceDescription


### PR DESCRIPTION
The Backend is changing to output the Distance to washrooms and buildings as kilometres. This was done for consistency between the radius input units and the distance output units. This PR handles displaying the new Distance units.

**Related PRs**:
-